### PR TITLE
fix: update gpt model (gpt 4 vision preview deprecated)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -11,7 +11,7 @@ export default {
 					'Content-Type': 'application/json',
 				},
 				body: JSON.stringify({
-					model: "gpt-4-vision-preview",
+					model: "gpt-4o",
 					max_tokens: 300,
 					messages: [
 					  {


### PR DESCRIPTION
GPT-4 vision preview is deprecated so updated that. Tested the API request on Postman to be working. 

Suggestion: the GPT model should be a field with a sensible default that can be overridden in case this changes again (likely needed as GPT models are continuously deprecated).